### PR TITLE
Remove unused ESLint CSS dependency and plugin

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,7 +3,6 @@ import globals from 'globals';
 import tseslint from 'typescript-eslint';
 import json from '@eslint/json';
 import markdown from '@eslint/markdown';
-import css from '@eslint/css';
 import { defineConfig } from 'eslint/config';
 import prettier from 'eslint-plugin-prettier';
 import eslintConfigPrettier from 'eslint-config-prettier';
@@ -30,7 +29,6 @@ export default defineConfig([
         language: 'markdown/gfm',
         extends: ['markdown/recommended'],
     },
-    { files: ['**/*.css'], plugins: { css }, language: 'css/css', extends: ['css/recommended'] },
     {
         files: ['**/*.{js,mjs,cjs,ts,mts,cts}'],
         plugins: {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
         "typescript": "^5.8.3"
     },
     "devDependencies": {
-        "@eslint/css": "^0.8.1",
         "@eslint/js": "^9.27.0",
         "@eslint/json": "^0.12.0",
         "@eslint/markdown": "^6.4.0",


### PR DESCRIPTION
Eliminate the unused @eslint/css dependency from package.json and remove the corresponding CSS plugin from the ESLint configuration.